### PR TITLE
Refactor import path for ease of use

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -17,9 +17,7 @@ body:
 
         ```python
         # Include all the necessary imports at the beginning
-        from prompttools.harness.prompt_template_harness import (
-            PromptTemplateExperimentationHarness,
-        )
+        from prompttools.harness import PromptTemplateExperimentationHarness
 
         # A succinct reproducible example trimmed down to the essential parts:
         prompt_templates = ["Answer the following question: {{input}}", "Respond the following query: {{input}}"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ There are a few different ways to run an experiment in a notebook.
 The simplest way is to define an experimentation harness and an evaluation function:
 
 ```python
+from prompttools.harness import PromptTemplateExperimentationHarness
+
+
 def eval_fn(prompt: str, results: Dict, metadata: Dict) -> float:
     # Your logic here, or use a built-in one such as `prompttools.utils.similarity`.
     pass

--- a/examples/notebooks/AutoEval.ipynb
+++ b/examples/notebooks/AutoEval.ipynb
@@ -260,9 +260,7 @@
    "outputs": [],
    "source": [
     "from typing import Dict\n",
-    "from prompttools.harness.prompt_template_harness import (\n",
-    "    PromptTemplateExperimentationHarness,\n",
-    ")"
+    "from prompttools.harness import PromptTemplateExperimentationHarness"
    ]
   },
   {

--- a/examples/notebooks/BasicExperiment.ipynb
+++ b/examples/notebooks/BasicExperiment.ipynb
@@ -260,7 +260,7 @@
    "outputs": [],
    "source": [
     "from typing import Dict, List, Tuple\n",
-    "from prompttools.experiment.openai_chat_experiment import OpenAIChatExperiment"
+    "from prompttools.experiment import OpenAIChatExperiment"
    ]
   },
   {

--- a/examples/notebooks/HumanFeedback.ipynb
+++ b/examples/notebooks/HumanFeedback.ipynb
@@ -259,9 +259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from prompttools.harness.prompt_template_harness import (\n",
-    "    PromptTemplateExperimentationHarness,\n",
-    ")"
+    "from prompttools.harness import PromptTemplateExperimentationHarness"
    ]
   },
   {

--- a/examples/notebooks/ModelComparison.ipynb
+++ b/examples/notebooks/ModelComparison.ipynb
@@ -259,9 +259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from prompttools.harness.chat_model_comparison_harness import (\n",
-    "    ChatModelComparisonHarness,\n",
-    ")"
+    "from prompttools.harness import ChatModelComparisonHarness"
    ]
   },
   {

--- a/examples/notebooks/SemanticSimilarity.ipynb
+++ b/examples/notebooks/SemanticSimilarity.ipynb
@@ -260,9 +260,7 @@
    "outputs": [],
    "source": [
     "from typing import Dict, Tuple\n",
-    "from prompttools.harness.prompt_template_harness import (\n",
-    "    PromptTemplateExperimentationHarness,\n",
-    ")"
+    "from prompttools.harness import PromptTemplateExperimentationHarness"
    ]
   },
   {

--- a/prompttools/experiment/__init__.py
+++ b/prompttools/experiment/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Hegel AI, Inc.
+# All rights reserved.
+#
+# This source code's license can be found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from experiment import Experiment
+from openai_chat_experiment import OpenAIChatExperiment
+from openai_completion_experiment import OpenAICompletionExperiment
+
+
+__all__ = ["OpenAIChatExperiment", "OpenAICompletionExperiment"]

--- a/prompttools/experiment/openai_chat_experiment.py
+++ b/prompttools/experiment/openai_chat_experiment.py
@@ -11,7 +11,7 @@ import openai
 import logging
 
 from prompttools.mock.mock import mock_chat_completion_fn
-from prompttools.experiment.experiment import Experiment
+from prompttools.experiment import Experiment
 
 
 class OpenAIChatExperiment(Experiment):

--- a/prompttools/experiment/openai_completion_experiment.py
+++ b/prompttools/experiment/openai_completion_experiment.py
@@ -10,7 +10,7 @@ import openai
 import logging
 
 from prompttools.mock.mock import mock_completion_fn
-from prompttools.experiment.experiment import Experiment
+from prompttools.experiment import Experiment
 
 
 class OpenAICompletionExperiment(Experiment):

--- a/prompttools/harness/__init__.py
+++ b/prompttools/harness/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) Hegel AI, Inc.
+# All rights reserved.
+#
+# This source code's license can be found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from chat_history_harness import ChatHistoryExperimentationHarness
+from chat_model_comparison_harness import ChatModelComparisonHarness
+from harness import ExperimentationHarness
+from prompt_template_harness import PromptTemplateExperimentationHarness
+from system_prompt_harness import SystemPromptExperimentationHarness
+
+
+__all__ = [
+    "ChatHistoryExperimentationHarness",
+    "ChatModelComparisonHarness",
+    "ExperimentationHarness",
+    "PromptTemplateExperimentationHarness",
+    "SystemPromptExperimentationHarness",
+]

--- a/prompttools/harness/chat_history_harness.py
+++ b/prompttools/harness/chat_history_harness.py
@@ -5,8 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Dict, List, Optional
-from prompttools.harness.harness import ExperimentationHarness
-from prompttools.experiment.openai_chat_experiment import OpenAIChatExperiment
+from prompttools.harness import ExperimentationHarness
+from prompttools.experiment import OpenAIChatExperiment
 
 
 class ChatHistoryExperimentationHarness(ExperimentationHarness):

--- a/prompttools/harness/chat_model_comparison_harness.py
+++ b/prompttools/harness/chat_model_comparison_harness.py
@@ -5,8 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Dict, List, Optional
-from prompttools.harness.harness import ExperimentationHarness
-from prompttools.experiment.openai_chat_experiment import OpenAIChatExperiment
+from prompttools.harness import ExperimentationHarness
+from prompttools.experiment import OpenAIChatExperiment
 
 
 class ChatModelComparisonHarness(ExperimentationHarness):

--- a/prompttools/harness/harness.py
+++ b/prompttools/harness/harness.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Callable, Dict, List
-from prompttools.experiment.experiment import Experiment
+from prompttools.experiment import Experiment
 
 
 class ExperimentationHarness:

--- a/prompttools/harness/prompt_template_harness.py
+++ b/prompttools/harness/prompt_template_harness.py
@@ -6,10 +6,8 @@
 
 from typing import Dict, List, Optional
 import jinja2
-from prompttools.harness.harness import ExperimentationHarness
-from prompttools.experiment.openai_completion_experiment import (
-    OpenAICompletionExperiment,
-)
+from prompttools.harness import ExperimentationHarness
+from prompttools.experiment import OpenAICompletionExperiment
 
 
 class PromptTemplateExperimentationHarness(ExperimentationHarness):

--- a/prompttools/harness/system_prompt_harness.py
+++ b/prompttools/harness/system_prompt_harness.py
@@ -5,8 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Dict, List, Optional
-from prompttools.harness.harness import ExperimentationHarness
-from prompttools.experiment.openai_chat_experiment import OpenAIChatExperiment
+from prompttools.harness import ExperimentationHarness
+from prompttools.experiment import OpenAIChatExperiment
 
 
 class SystemPromptExperimentationHarness(ExperimentationHarness):

--- a/prompttools/testing/runner/prompt_template_runner.py
+++ b/prompttools/testing/runner/prompt_template_runner.py
@@ -4,9 +4,7 @@ import logging
 
 from prompttools.testing.threshold_type import ThresholdType
 from prompttools.testing.error.failure import log_failure
-from prompttools.harness.prompt_template_harness import (
-    PromptTemplateExperimentationHarness,
-)
+from prompttools.harness import PromptTemplateExperimentationHarness
 from prompttools.testing.runner.runner import PromptTestRunner
 from prompttools.testing.error.failure import PromptTestSetupException
 

--- a/prompttools/testing/runner/system_prompt_runner.py
+++ b/prompttools/testing/runner/system_prompt_runner.py
@@ -4,7 +4,7 @@ import logging
 
 from prompttools.testing.threshold_type import ThresholdType
 from prompttools.testing.error.failure import log_failure
-from prompttools.harness.system_prompt_harness import SystemPromptExperimentationHarness
+from prompttools.harness import SystemPromptExperimentationHarness
 from prompttools.testing.runner.runner import PromptTestRunner
 from prompttools.testing.error.failure import PromptTestSetupException
 


### PR DESCRIPTION
Refactoring import path for easier import pattern. It should not be BC-breaking. It will also allow a easier time to move classes around in the future (as long as the import path will be updated).

We should update the package with this PR as well.