### PR TITLE
feat: add MiniMax as first-class LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ LLMs
 - HuggingFace (Hub API, Inference Endpoints) - **Supported**
 - Anthropic - **Supported**
 - Mistral AI - **Supported**
+- MiniMax - **Supported**
 - Google Gemini - **Supported**
 - Google PaLM (legacy) - **Supported**
 - Google Vertex AI - **Supported**

--- a/prompttools/experiment/__init__.py
+++ b/prompttools/experiment/__init__.py
@@ -17,6 +17,7 @@ from .experiments.llama_cpp_experiment import LlamaCppExperiment
 from .experiments.chromadb_experiment import ChromaDBExperiment
 from .experiments.weaviate_experiment import WeaviateExperiment
 from .experiments.lancedb_experiment import LanceDBExperiment
+from .experiments.minimax_chat_experiment import MiniMaxChatExperiment
 from .experiments.mistral_experiment import MistralChatCompletionExperiment
 from .experiments.mindsdb_experiment import MindsDBExperiment
 from .experiments.langchain_experiment import SequentialChainExperiment, RouterChainExperiment
@@ -36,6 +37,7 @@ __all__ = [
     "LanceDBExperiment",
     "LlamaCppExperiment",
     "HuggingFaceHubExperiment",
+    "MiniMaxChatExperiment",
     "MistralChatCompletionExperiment",
     "MindsDBExperiment",
     "MusicGenExperiment",

--- a/prompttools/experiment/experiments/minimax_chat_experiment.py
+++ b/prompttools/experiment/experiments/minimax_chat_experiment.py
@@ -1,0 +1,126 @@
+# Copyright (c) Hegel AI, Inc.
+# All rights reserved.
+#
+# This source code's license can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+
+from typing import Dict, List, Optional, Union
+
+import openai
+
+from prompttools.selector.prompt_selector import PromptSelector
+from prompttools.mock.mock import mock_minimax_chat_completion_fn
+from .experiment import Experiment
+
+
+MINIMAX_API_BASE = "https://api.minimax.io/v1"
+
+
+class MiniMaxChatExperiment(Experiment):
+    r"""
+    This class defines an experiment for MiniMax's chat completion API.
+    It accepts lists for each argument passed into the API, then creates
+    a cartesian product of those arguments, and gets results for each.
+
+    MiniMax provides an OpenAI-compatible chat completions endpoint, so this
+    experiment uses the ``openai`` library with a custom ``base_url``.
+
+    Note:
+        - All arguments here should be a ``list``, even if you want to keep the argument frozen
+          (i.e. ``temperature=[1.0]``), because the experiment will try all possible combination
+          of the input arguments.
+        - You should set ``os.environ["MINIMAX_API_KEY"] = YOUR_KEY`` in order to connect
+          with MiniMax's API.
+
+    Args:
+        model (list[str]):
+            The model(s) to use. Available models include ``"MiniMax-M2.7"``,
+            ``"MiniMax-M2.7-highspeed"``, ``"MiniMax-M2.5"``, and
+            ``"MiniMax-M2.5-highspeed"``.
+
+        messages (list[list[dict[str, str]]]):
+            Input prompts using the OpenAI message format. Each message is a
+            dictionary with ``role`` and ``content`` keys.
+
+        temperature (list[float], optional):
+            The sampling temperature. MiniMax requires values in (0.0, 1.0].
+            Defaults to ``[1.0]``.
+
+        top_p (list[float], optional):
+            Nucleus sampling parameter. Defaults to ``[1.0]``.
+
+        max_tokens (list[int], optional):
+            The maximum number of tokens to generate. Defaults to ``[None]``.
+
+        stop (list[list[str]], optional):
+            Up to 4 sequences where the API will stop generating further tokens.
+            Defaults to ``[None]``.
+    """
+
+    url = "https://api.minimax.io/v1/chat/completions"
+
+    def __init__(
+        self,
+        model: List[str] = ["MiniMax-M2.5"],
+        messages: Union[List[List[Dict[str, str]]], List[PromptSelector]] = [],
+        temperature: Optional[List[float]] = [1.0],
+        top_p: Optional[List[float]] = [1.0],
+        max_tokens: Optional[List[Optional[int]]] = [None],
+        stop: Optional[List[Optional[List[str]]]] = [None],
+    ):
+        self.client = openai.OpenAI(
+            api_key=os.environ.get("MINIMAX_API_KEY", ""),
+            base_url=MINIMAX_API_BASE,
+        )
+        self.completion_fn = self.minimax_completion_fn
+
+        if os.getenv("DEBUG", default=False):
+            self.completion_fn = mock_minimax_chat_completion_fn
+
+        # Handle PromptSelector
+        if len(messages) > 0 and isinstance(messages[0], PromptSelector):
+            self.prompt_keys = {
+                str(selector.for_openai_chat()[-1]["content"]): selector.for_llama() for selector in messages
+            }
+            messages = [selector.for_openai_chat() for selector in messages]
+        else:
+            self.prompt_keys = messages
+
+        # Clamp temperature: MiniMax requires (0.0, 1.0]
+        clamped_temperature = []
+        for t in temperature:
+            if t is not None:
+                t = max(0.01, min(t, 1.0))
+            clamped_temperature.append(t)
+
+        self.all_args = dict(
+            model=model,
+            messages=messages,
+            temperature=clamped_temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            stop=stop,
+        )
+        super().__init__()
+
+    def minimax_completion_fn(self, **input_args):
+        response = self.client.chat.completions.create(**input_args)
+        return response
+
+    @staticmethod
+    def _extract_responses(response) -> str:
+        return response.choices[0].message.content
+
+    @staticmethod
+    def _is_chat():
+        return True
+
+    def _get_model_names(self):
+        return [combo["model"] for combo in self.argument_combos]
+
+    def _get_prompts(self):
+        if isinstance(self.prompt_keys, dict):
+            return [self.prompt_keys[str(combo["messages"][-1]["content"])] for combo in self.argument_combos]
+        return [combo["messages"] for combo in self.argument_combos]

--- a/prompttools/mock/mock.py
+++ b/prompttools/mock/mock.py
@@ -201,6 +201,32 @@ def mock_qdrant_fn(**kwargs):
     ]
 
 
+def mock_minimax_chat_completion_fn(**kwargs):
+    return DotDict(
+        {
+            "choices": [
+                DotDict(
+                    {
+                        "finish_reason": "stop",
+                        "index": 0,
+                        "message": DotDict(
+                            {
+                                "content": "George Washington",
+                                "role": "assistant",
+                            }
+                        ),
+                    }
+                )
+            ],
+            "created": 1687839008,
+            "id": "",
+            "model": "MiniMax-M2.5",
+            "object": "chat.completion",
+            "usage": DotDict({"completion_tokens": 18, "prompt_tokens": 57, "total_tokens": 75}),
+        }
+    )
+
+
 def mock_music_gen_completion_fn(**kwargs):
     y, sr = librosa.load("../../examples/notebooks/audio_experiments/sample_audio_files/80s_billy_joel.wav")
     # Extract relevant features, for example, Mel-frequency cepstral coefficients (MFCCs)

--- a/prompttools/playground/constants.py
+++ b/prompttools/playground/constants.py
@@ -12,6 +12,7 @@ from prompttools.experiment import AnthropicCompletionExperiment
 from prompttools.experiment import GooglePaLMCompletionExperiment
 from prompttools.experiment import HuggingFaceHubExperiment
 from prompttools.experiment import ReplicateExperiment
+from prompttools.experiment import MiniMaxChatExperiment
 
 ENVIRONMENT_VARIABLE = {
     "Replicate": "REPLICATE_API_TOKEN",
@@ -20,6 +21,7 @@ ENVIRONMENT_VARIABLE = {
     "Anthropic": "ANTHROPIC_API_KEY",
     "Google PaLM": "GOOGLE_PALM_API_KEY",
     "HuggingFace Hub": "HUGGINGFACEHUB_API_TOKEN",
+    "MiniMax Chat": "MINIMAX_API_KEY",
 }
 
 EXPERIMENTS = {
@@ -30,6 +32,7 @@ EXPERIMENTS = {
     "Google PaLM": GooglePaLMCompletionExperiment,
     "HuggingFace Hub": HuggingFaceHubExperiment,
     "Replicate": ReplicateExperiment,
+    "MiniMax Chat": MiniMaxChatExperiment,
 }
 
 MODES = ("Instruction", "Prompt Template", "Model Comparison")
@@ -43,6 +46,7 @@ MODEL_TYPES = (
     "LlamaCpp Completion",
     "HuggingFace Hub",
     "Replicate",
+    "MiniMax Chat",
 )
 
 OPENAI_CHAT_MODELS = (
@@ -60,3 +64,10 @@ OPENAI_CHAT_MODELS = (
 )
 
 OPENAI_COMPLETION_MODELS = ("text-davinci-003", "text-davinci-002", "code-davinci-002")
+
+MINIMAX_CHAT_MODELS = (
+    "MiniMax-M2.7",
+    "MiniMax-M2.7-highspeed",
+    "MiniMax-M2.5",
+    "MiniMax-M2.5-highspeed",
+)

--- a/test/test_minimax_experiment.py
+++ b/test/test_minimax_experiment.py
@@ -1,0 +1,380 @@
+# Copyright (c) Hegel AI, Inc.
+# All rights reserved.
+#
+# This source code's license can be found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Unit and integration tests for MiniMaxChatExperiment.
+"""
+
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+from prompttools.experiment import MiniMaxChatExperiment
+from prompttools.mock.mock import mock_minimax_chat_completion_fn, DotDict
+
+
+class TestMiniMaxChatExperimentImport(unittest.TestCase):
+    """Test that MiniMaxChatExperiment can be imported properly."""
+
+    def test_import_from_experiment(self):
+        from prompttools.experiment import MiniMaxChatExperiment
+        self.assertIsNotNone(MiniMaxChatExperiment)
+
+    def test_in_all_exports(self):
+        from prompttools.experiment import __all__
+        self.assertIn("MiniMaxChatExperiment", __all__)
+
+
+class TestMiniMaxChatExperimentInit(unittest.TestCase):
+    """Test MiniMaxChatExperiment initialization."""
+
+    def test_default_init(self):
+        """Test that the experiment initializes with default parameters."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5"],
+            messages=[[{"role": "user", "content": "Hello"}]],
+        )
+        self.assertIsNotNone(experiment)
+        self.assertEqual(experiment.all_args["model"], ["MiniMax-M2.5"])
+        self.assertEqual(experiment.all_args["temperature"], [1.0])
+        self.assertEqual(experiment.all_args["top_p"], [1.0])
+
+    def test_multiple_models(self):
+        """Test initialization with multiple models."""
+        models = ["MiniMax-M2.7", "MiniMax-M2.5"]
+        experiment = MiniMaxChatExperiment(
+            model=models,
+            messages=[[{"role": "user", "content": "Hello"}]],
+        )
+        self.assertEqual(experiment.all_args["model"], models)
+
+    def test_temperature_clamping_zero(self):
+        """Test that temperature 0.0 is clamped to 0.01."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5"],
+            messages=[[{"role": "user", "content": "Hello"}]],
+            temperature=[0.0],
+        )
+        self.assertEqual(experiment.all_args["temperature"], [0.01])
+
+    def test_temperature_clamping_high(self):
+        """Test that temperature > 1.0 is clamped to 1.0."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5"],
+            messages=[[{"role": "user", "content": "Hello"}]],
+            temperature=[2.0],
+        )
+        self.assertEqual(experiment.all_args["temperature"], [1.0])
+
+    def test_temperature_valid(self):
+        """Test that a valid temperature passes through."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5"],
+            messages=[[{"role": "user", "content": "Hello"}]],
+            temperature=[0.7],
+        )
+        self.assertEqual(experiment.all_args["temperature"], [0.7])
+
+    def test_temperature_none(self):
+        """Test that None temperature is kept as None."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5"],
+            messages=[[{"role": "user", "content": "Hello"}]],
+            temperature=[None],
+        )
+        self.assertEqual(experiment.all_args["temperature"], [None])
+
+    def test_custom_params(self):
+        """Test initialization with custom parameters."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.7"],
+            messages=[[{"role": "user", "content": "Hello"}]],
+            temperature=[0.5],
+            top_p=[0.9],
+            max_tokens=[1024],
+            stop=[["END"]],
+        )
+        self.assertEqual(experiment.all_args["max_tokens"], [1024])
+        self.assertEqual(experiment.all_args["stop"], [["END"]])
+        self.assertEqual(experiment.all_args["top_p"], [0.9])
+
+
+class TestMiniMaxChatExperimentMethods(unittest.TestCase):
+    """Test MiniMaxChatExperiment methods."""
+
+    def setUp(self):
+        self.experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5"],
+            messages=[
+                [{"role": "user", "content": "Who was the first president?"}],
+            ],
+            temperature=[0.5],
+        )
+
+    def test_is_chat(self):
+        """Test that _is_chat returns True."""
+        self.assertTrue(MiniMaxChatExperiment._is_chat())
+
+    def test_prepare_creates_argument_combos(self):
+        """Test that prepare creates argument combinations."""
+        self.experiment.prepare()
+        self.assertEqual(len(self.experiment.argument_combos), 1)
+        self.assertEqual(self.experiment.argument_combos[0]["model"], "MiniMax-M2.5")
+
+    def test_prepare_cartesian_product(self):
+        """Test that prepare creates cartesian product of arguments."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5", "MiniMax-M2.7"],
+            messages=[
+                [{"role": "user", "content": "Hello"}],
+            ],
+            temperature=[0.5, 1.0],
+        )
+        experiment.prepare()
+        # 2 models * 1 message * 2 temperatures = 4 combos
+        self.assertEqual(len(experiment.argument_combos), 4)
+
+    def test_get_model_names(self):
+        """Test _get_model_names returns correct model names."""
+        self.experiment.prepare()
+        names = self.experiment._get_model_names()
+        self.assertEqual(names, ["MiniMax-M2.5"])
+
+    def test_extract_responses(self):
+        """Test _extract_responses with mock response."""
+        response = mock_minimax_chat_completion_fn()
+        result = MiniMaxChatExperiment._extract_responses(response)
+        self.assertEqual(result, "George Washington")
+
+    def test_url(self):
+        """Test that the URL is set correctly."""
+        self.assertEqual(
+            MiniMaxChatExperiment.url,
+            "https://api.minimax.io/v1/chat/completions",
+        )
+
+
+class TestMiniMaxChatMockFunction(unittest.TestCase):
+    """Test the mock function for MiniMax chat completions."""
+
+    def test_mock_returns_dotdict(self):
+        """Test that mock returns a DotDict."""
+        result = mock_minimax_chat_completion_fn()
+        self.assertIsInstance(result, DotDict)
+
+    def test_mock_has_choices(self):
+        """Test that mock response has choices."""
+        result = mock_minimax_chat_completion_fn()
+        self.assertIn("choices", result)
+        self.assertEqual(len(result["choices"]), 1)
+
+    def test_mock_content(self):
+        """Test mock response content."""
+        result = mock_minimax_chat_completion_fn()
+        self.assertEqual(result.choices[0].message.content, "George Washington")
+
+    def test_mock_model(self):
+        """Test mock response model."""
+        result = mock_minimax_chat_completion_fn()
+        self.assertEqual(result.model, "MiniMax-M2.5")
+
+    def test_mock_usage(self):
+        """Test mock response usage."""
+        result = mock_minimax_chat_completion_fn()
+        self.assertEqual(result.usage.total_tokens, 75)
+
+    def test_mock_finish_reason(self):
+        """Test mock response finish_reason."""
+        result = mock_minimax_chat_completion_fn()
+        self.assertEqual(result.choices[0].finish_reason, "stop")
+
+
+class TestMiniMaxChatExperimentDebugMode(unittest.TestCase):
+    """Test MiniMaxChatExperiment in DEBUG mode."""
+
+    @patch.dict(os.environ, {"DEBUG": "1"})
+    def test_debug_uses_mock(self):
+        """Test that DEBUG mode uses mock completion function."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5"],
+            messages=[[{"role": "user", "content": "Hello"}]],
+        )
+        self.assertEqual(experiment.completion_fn, mock_minimax_chat_completion_fn)
+
+    @patch.dict(os.environ, {"DEBUG": "1"})
+    def test_debug_run(self):
+        """Test running the experiment in DEBUG mode."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5"],
+            messages=[[{"role": "user", "content": "Who was the first president?"}]],
+        )
+        experiment.run()
+        self.assertIsNotNone(experiment.full_df)
+        self.assertIsNotNone(experiment.partial_df)
+        self.assertIsNotNone(experiment.score_df)
+
+    @patch.dict(os.environ, {"DEBUG": "1"})
+    def test_debug_run_extracts_response(self):
+        """Test that DEBUG run extracts response correctly."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5"],
+            messages=[[{"role": "user", "content": "Who was the first president?"}]],
+        )
+        experiment.run()
+        self.assertIn("response", experiment.partial_df.columns)
+        self.assertEqual(experiment.partial_df["response"].iloc[0], "George Washington")
+
+    @patch.dict(os.environ, {"DEBUG": "1"})
+    def test_debug_run_multiple_models(self):
+        """Test DEBUG run with multiple models."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5", "MiniMax-M2.7"],
+            messages=[[{"role": "user", "content": "Hello"}]],
+        )
+        experiment.run()
+        self.assertEqual(len(experiment.full_df), 2)
+
+    @patch.dict(os.environ, {"DEBUG": "1"})
+    def test_debug_run_has_latency(self):
+        """Test that DEBUG run records latency."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5"],
+            messages=[[{"role": "user", "content": "Hello"}]],
+        )
+        experiment.run()
+        self.assertIn("latency", experiment.score_df.columns)
+        self.assertGreaterEqual(experiment.score_df["latency"].iloc[0], 0)
+
+    @patch.dict(os.environ, {"DEBUG": "1"})
+    def test_debug_run_to_csv(self):
+        """Test exporting DEBUG run results to CSV."""
+        import tempfile
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5"],
+            messages=[[{"role": "user", "content": "Hello"}]],
+        )
+        experiment.run()
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=True) as f:
+            experiment.to_csv(f.name)
+            self.assertTrue(os.path.exists(f.name))
+
+    @patch.dict(os.environ, {"DEBUG": "1"})
+    def test_debug_cartesian_product(self):
+        """Test cartesian product of arguments in DEBUG mode."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5", "MiniMax-M2.7"],
+            messages=[
+                [{"role": "user", "content": "Hello"}],
+                [{"role": "user", "content": "World"}],
+            ],
+            temperature=[0.5, 1.0],
+        )
+        experiment.run()
+        # 2 models * 2 messages * 2 temperatures = 8
+        self.assertEqual(len(experiment.full_df), 8)
+
+
+class TestMiniMaxChatExperimentPlayground(unittest.TestCase):
+    """Test MiniMax integration in playground constants."""
+
+    def test_playground_experiment_registered(self):
+        from prompttools.playground.constants import EXPERIMENTS
+        self.assertIn("MiniMax Chat", EXPERIMENTS)
+        self.assertEqual(EXPERIMENTS["MiniMax Chat"], MiniMaxChatExperiment)
+
+    def test_playground_env_var_registered(self):
+        from prompttools.playground.constants import ENVIRONMENT_VARIABLE
+        self.assertIn("MiniMax Chat", ENVIRONMENT_VARIABLE)
+        self.assertEqual(ENVIRONMENT_VARIABLE["MiniMax Chat"], "MINIMAX_API_KEY")
+
+    def test_playground_model_type_registered(self):
+        from prompttools.playground.constants import MODEL_TYPES
+        self.assertIn("MiniMax Chat", MODEL_TYPES)
+
+    def test_playground_minimax_models(self):
+        from prompttools.playground.constants import MINIMAX_CHAT_MODELS
+        self.assertIn("MiniMax-M2.7", MINIMAX_CHAT_MODELS)
+        self.assertIn("MiniMax-M2.5", MINIMAX_CHAT_MODELS)
+
+
+class TestMiniMaxChatExperimentInitialize(unittest.TestCase):
+    """Test the alternative initialize() class method."""
+
+    def test_initialize_class_method(self):
+        """Test initialization via the initialize class method."""
+        test_params = {"model": ["MiniMax-M2.5", "MiniMax-M2.7"]}
+        frozen_params = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "temperature": 0.5,
+        }
+        experiment = MiniMaxChatExperiment.initialize(test_params, frozen_params)
+        self.assertIsNotNone(experiment)
+        self.assertEqual(len(experiment.all_args["model"]), 2)
+
+
+class TestMiniMaxChatIntegration(unittest.TestCase):
+    """Integration tests for MiniMax chat experiment.
+
+    These tests require a valid MINIMAX_API_KEY environment variable.
+    They are skipped if the key is not available.
+    """
+
+    @unittest.skipUnless(
+        os.environ.get("MINIMAX_API_KEY"),
+        "MINIMAX_API_KEY not set, skipping integration tests",
+    )
+    def test_live_single_completion(self):
+        """Test a live single completion call to MiniMax API."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5"],
+            messages=[[{"role": "user", "content": "What is 2+2? Answer with just the number."}]],
+            temperature=[0.01],
+            max_tokens=[32],
+        )
+        experiment.run()
+        self.assertIsNotNone(experiment.full_df)
+        response = experiment.partial_df["response"].iloc[0]
+        self.assertIsNotNone(response)
+        self.assertTrue(len(response) > 0)
+
+    @unittest.skipUnless(
+        os.environ.get("MINIMAX_API_KEY"),
+        "MINIMAX_API_KEY not set, skipping integration tests",
+    )
+    def test_live_model_comparison(self):
+        """Test comparing two MiniMax models."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5", "MiniMax-M2.5-highspeed"],
+            messages=[[{"role": "user", "content": "Say hello in one word."}]],
+            temperature=[0.5],
+            max_tokens=[32],
+        )
+        experiment.run()
+        self.assertEqual(len(experiment.full_df), 2)
+
+    @unittest.skipUnless(
+        os.environ.get("MINIMAX_API_KEY"),
+        "MINIMAX_API_KEY not set, skipping integration tests",
+    )
+    def test_live_evaluate(self):
+        """Test running evaluation on live results."""
+        experiment = MiniMaxChatExperiment(
+            model=["MiniMax-M2.5"],
+            messages=[[{"role": "user", "content": "What is the capital of France?"}]],
+            temperature=[0.5],
+            max_tokens=[64],
+        )
+        experiment.run()
+
+        def contains_paris(row, response_column_name="response"):
+            return "paris" in row[response_column_name].lower()
+
+        experiment.evaluate("contains_paris", contains_paris)
+        self.assertIn("contains_paris", experiment.score_df.columns)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimax.io/) as a first-class LLM provider in prompttools, enabling users to test and compare MiniMax models alongside existing providers like OpenAI, Anthropic, and Mistral.

### Changes

- **New `MiniMaxChatExperiment` class** (`prompttools/experiment/experiments/minimax_chat_experiment.py`): Extends the `Experiment` base class using MiniMax's OpenAI-compatible chat completions API via the `openai` library (already a dependency) with custom `base_url`
- **Supported models**: `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`
- **Temperature clamping**: Automatically clamps temperature values to MiniMax's required (0.0, 1.0] range
- **DEBUG mode**: Mock function added for testing without API calls
- **Playground integration**: Registered as "MiniMax Chat" in the Streamlit playground UI
- **Comprehensive tests**: 33 unit tests + 3 integration tests covering initialization, parameter handling, mock responses, playground registration, and live API calls
- **README**: Updated supported integrations list

### Usage

```python
from prompttools.experiment import MiniMaxChatExperiment

messages = [
    [{"role": "user", "content": "Tell me a joke."}],
    [{"role": "user", "content": "Is 17077 a prime number?"}],
]

experiment = MiniMaxChatExperiment(
    model=["MiniMax-M2.7", "MiniMax-M2.5"],
    messages=messages,
    temperature=[0.5],
)
experiment.run()
experiment.visualize()
```

## Test Plan

- [x] All 33 unit tests passing (import, init, temperature clamping, mock, playground registration, cartesian product, DEBUG mode)
- [x] All 3 integration tests passing with live MiniMax API calls (single completion, model comparison, evaluate)
- [x] Follows existing provider patterns (Mistral, OpenAI)