### PR TITLE
ci: update actions/checkout@v7 and actions/setup-python@v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
     - name: Check out source repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
     - name: Check out source repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Updates the CI workflow to use current action versions.

Changes:
- `actions/checkout@v3` -> `actions/checkout@v7`
- `actions/setup-python@v3` -> `actions/setup-python@v7`

The workflow does not use the `pip-install` input, which setup-python v7 removed, so the bump is a drop-in change.

Validation:
- workflow YAML parses after the change
- `comment.yml` still references older action versions; it was left out of this PR to keep the diff focused on ci.yml. Happy to send a follow-up if wanted.

Scope: `.github/workflows/ci.yml` only.

Note: the first push of this branch stopped at v4 and v5; the follow-up force-push brought both to the current major, v7. Commit author katsugtgz, unsigned.